### PR TITLE
Fixed SecurityError raised because of calling history.replaceState too often

### DIFF
--- a/oom/oomview.js
+++ b/oom/oomview.js
@@ -9,6 +9,7 @@
 */
 
 var oommodel            = require('./oommodel');
+var _                   = require('lodash');
 
 $.defPage('', 
           function(o) {
@@ -30,10 +31,10 @@ $.defPage('',
             }).bogartBodyEvents({
               'keydown': onBodyKeydown
             });
-
-            m.on('changed', function() {
+  
+            m.on('changed', _.debounce(function() { // Debouncing to avoid calling replaceHistory too often
               replaceLocationHash('', m.asParms());
-            });
+            }, 500));
             
             getSizes();
             adjustSizes();


### PR DESCRIPTION
Changing the input data triggers changing hash, that leads to a SecurityError raised by some browsers (e.g. Safari 12). This in turn makes the page no longer usable.

This fix makes updating of the hash debounced.